### PR TITLE
Simplify gencode

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -827,10 +827,6 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << sb;
     out << nl << "let sz = try Swift.Int(istr.readSize())";
     out << nl;
-    if (p->valueType()->isClassType())
-    {
-        out << "nonisolated(unsafe) ";
-    }
     out << "var v = " << name << "()";
     if (p->valueType()->isClassType())
     {


### PR DESCRIPTION
This `nonisolated(unsafe)` is not necessary.